### PR TITLE
Fix Next.js build without DATABASE_URL by lazily instantiating db client

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,11 +1,13 @@
-import { drizzle } from "drizzle-orm/postgres-js";
+import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema";
 
-// Create a lazy database instance that only initializes when accessed
-let _db: ReturnType<typeof drizzle> | null = null;
+type Database = PostgresJsDatabase<typeof schema>;
 
-function getDb() {
+// Create a lazy database instance that only initializes when accessed
+let _db: Database | null = null;
+
+function getDb(): Database {
   if (!process.env.DATABASE_URL) {
     throw new Error("DATABASE_URL is not set");
   }
@@ -18,8 +20,17 @@ function getDb() {
   return _db;
 }
 
-// Export a proxy that forwards all calls to the actual db instance
-export const db = getDb();
+// Export a proxy that forwards all calls to the actual db instance without
+// initializing the connection during module evaluation. This prevents build
+// steps (which often run without DATABASE_URL) from failing while still
+// throwing a helpful error when the database is accessed at runtime.
+export const db: Database = new Proxy({} as Database, {
+  get(_target, prop, receiver) {
+    const instance = getDb();
+    const value = Reflect.get(instance, prop, receiver);
+    return typeof value === "function" ? value.bind(instance) : value;
+  },
+});
 
 // Re-export schema for convenience
 export * from "./schema";


### PR DESCRIPTION
## Summary
- defer creation of the drizzle database client until it is actually used
- use a proxy to lazily access the client so builds without DATABASE_URL no longer fail

## Testing
- bun run build *(fails: Next.js cannot fetch Google Fonts in this environment)*
- bun run lint *(fails: command requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9e2c51b483229a2dea21ef83bfff